### PR TITLE
Added `FixedSecond` cubic spline type

### DIFF
--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -62,6 +62,7 @@ public:
 		{"Not-a-knot", alfi::spline::CubicSpline<>::Types::NotAKnot{}},
 		{"Periodic", alfi::spline::CubicSpline<>::Types::Periodic{}},
 		{"Clamped(0, 10)", alfi::spline::CubicSpline<>::Types::Clamped{0, 10}},
+		{"FixedSecond(40, 20)", alfi::spline::CubicSpline<>::Types::FixedSecond{40, 20}},
 		{"Not-a-knot start", alfi::spline::CubicSpline<>::Types::NotAKnotStart{}},
 		{"Not-a-knot end", alfi::spline::CubicSpline<>::Types::NotAKnotEnd{}},
 		{"Semi-not-a-knot", alfi::spline::CubicSpline<>::Types::SemiNotAKnot{}},


### PR DESCRIPTION
### Types of changes
- Feature
- Refactoring, reformatting, cleanup

Related: #7, #11

### Description
1. Implemented `FixedSecond` type for splines with known second derivatives at the ends.
2. Replaced `Natural` type implementation through `FixedSecond{0, 0}`.