### PR TITLE
Replaced submodule URLs from SSH to HTTPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Install dependencies
         run: ./helper.py -d
       - name: Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        submodules: true
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "tests/deps/toml++"]
 	path = tests/deps/toml++
-	url = git@github.com:marzer/tomlplusplus
+	url = https://github.com/marzer/tomlplusplus
 	shallow = true
 [submodule "tests/test_data"]
 	path = tests/test_data
-	url = git@github.com:ALFI-library/test_data
+	url = https://github.com/ALFI-library/test_data
 	shallow = true


### PR DESCRIPTION
### Types of changes
- Configuration (CI/CD)

Related: #19

### Description
- HTTPS was chosen over SSH to avoid SSH key requirements.
- Removed `submodules: true` from workflows, as submodules are loaded during the "Install dependencies" step with `./helper.py -d` over HTTPS.